### PR TITLE
Fix Duplication Glitch with Name Presses

### DIFF
--- a/src/main/scala/net/bdew/ae2stuff/machines/inscriber/TileInscriber.scala
+++ b/src/main/scala/net/bdew/ae2stuff/machines/inscriber/TileInscriber.scala
@@ -260,7 +260,8 @@ class TileInscriber extends TileDataSlots with GridTile with SidedInventory with
     }
 
     val startingItem = input.copy
-    val renamedItem = input.copy
+    startingItem.setCount(1)
+    val renamedItem = startingItem.copy
     val tag = Platform.openNbtData(renamedItem)
 
     val display = tag.getCompoundTag("display")


### PR DESCRIPTION
This PR simply normalises the input and output item stack sizes in the advanced inscriber recipes for renaming to 1, fixing a duplication glitch.

Fixes https://github.com/AE2-UEL/ae2stuff/issues/11