### PR TITLE
Fix Edge Case Visualiser Divide By Zero Crash

### DIFF
--- a/src/main/scala/net/bdew/ae2stuff/items/visualiser/VisualiserOverlayRender.scala
+++ b/src/main/scala/net/bdew/ae2stuff/items/visualiser/VisualiserOverlayRender.scala
@@ -113,9 +113,9 @@ object VisualiserOverlayRender extends WorldOverlayRenderer {
       val z1 = link.node1.z
       val z2 = link.node2.z
 
-      val cx = (x1 - x2) / (x1 + x2)
-      val cy = (y1 - y2) / (y1 + y2)
-      val cz = (z1 - z2) / (z1 + z2)
+      val cx = (x1 + x2) / 2
+      val cy = (y1 + y2) / 2
+      val cz = (z1 + z2) / 2
       val dist = player.getDistanceSq(cx, cy, cz).toFloat
 
       val lineWidth = clamp(MathHelper.fastInvSqrt(dist) + (width.toInt >> 2), 1, width.toInt)


### PR DESCRIPTION
This PR fixes the network visualizer crashing when a link extends between two nodes that are either:
- Both on x = 0
- Both on y = 0
- Both on z = 0

This fix is done by changing the computations for `cx`, `cy`, and `cz` to be the midpoint of the nodes x, y, and z values (which is what I assume its meant to be?)